### PR TITLE
Fix issues with @actions/upload-artifact@4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
-        name: ${{ matrix.os }}--integration-logs
+        name: ${{ matrix.os }}-integration-logs
         path: '**/*.log'
 
   tox:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
-        name: integration-logs
+        name: ${{ matrix.os }}--integration-logs
         path: '**/*.log'
 
   tox:
@@ -134,5 +134,5 @@ jobs:
       uses: actions/upload-artifact@v4
       if: ${{ always() }}
       with:
-        name: tox-logs
+        name: ${{ matrix.python }}-tox-logs
         path: '**/*.log'


### PR DESCRIPTION
Unlike version 3 of `@actions/upload-artifact`, version 4 does not support uploading to the same named artifact multiple times.